### PR TITLE
[#46] Fix tower placement

### DIFF
--- a/src/Rpg/gamengine/RPGEngine.cpp
+++ b/src/Rpg/gamengine/RPGEngine.cpp
@@ -148,6 +148,7 @@ RPGEngine::RPGEngine(sf::RenderWindow& window, GameManager* gameManager)
 
     mAvailableTowers.push_back(2);
     mAvailableTowers.push_back(1);
+    mAvailableTowers.push_back(3);
 
     // Testing
     std::unique_ptr<Wood> woodItem = std::make_unique<Wood>();

--- a/src/Rpg/menues/StartTowerDefenseMenu.cpp
+++ b/src/Rpg/menues/StartTowerDefenseMenu.cpp
@@ -176,6 +176,8 @@ void StartTowerDefenseMenu::render(sf::RenderWindow& window) {
                 mTowerSlots[i].setFillColor(sf::Color::Green);
             else if (mSelectedTowers[i] == 2)
                 mTowerSlots[i].setFillColor(sf::Color::Red);
+            else if (mSelectedTowers[i] == 3)
+                mTowerSlots[i].setFillColor(sf::Color::Cyan);
         } else {
             mTowerSlots[i].setFillColor(sf::Color(0, 0, 0, 220));
         }
@@ -188,6 +190,8 @@ void StartTowerDefenseMenu::render(sf::RenderWindow& window) {
                 mSelectingTowerSlots[i].setFillColor(sf::Color::Green);
             else if (mAvailableTowers[i] == 2)
                 mSelectingTowerSlots[i].setFillColor(sf::Color::Red);
+            else if (mAvailableTowers[i] == 3)
+                mSelectingTowerSlots[i].setFillColor(sf::Color::Cyan);
         } else {
             mSelectingTowerSlots[i].setFillColor(sf::Color(0, 0, 0, 220));
         }

--- a/src/TowerDefense/gamengine/GameEngine.cpp
+++ b/src/TowerDefense/gamengine/GameEngine.cpp
@@ -164,12 +164,24 @@ void GameEngine::processEvents() {
                                                     newTower = new LaserTower(mousePos, mProjectiles);
                                                 else if (mAvailableTowers[0] == 2)
                                                     newTower = new FlameTurret(mousePos, mProjectiles);
+                                                else if (mAvailableTowers[0] == 3)
+                                                    newTower = new ThunderRod(mousePos, mProjectiles, mEnemies);
                                                 break;
                                             case 1:
                                                 if (mAvailableTowers[1] == 1)
                                                     newTower = new LaserTower(mousePos, mProjectiles);
                                                 else if (mAvailableTowers[1] == 2)
                                                     newTower = new FlameTurret(mousePos, mProjectiles);
+                                                else if (mAvailableTowers[1] == 3)
+                                                    newTower = new ThunderRod(mousePos, mProjectiles, mEnemies);
+                                                break;
+                                            case 2:
+                                                if (mAvailableTowers[2] == 1)
+                                                    newTower = new LaserTower(mousePos, mProjectiles);
+                                                else if (mAvailableTowers[2] == 2)
+                                                    newTower = new FlameTurret(mousePos, mProjectiles);
+                                                else if (mAvailableTowers[2] == 3)
+                                                    newTower = new ThunderRod(mousePos, mProjectiles, mEnemies);
                                                 break;
                                         }
 
@@ -268,12 +280,24 @@ void GameEngine::handleNonTowerClick(const sf::Vector2f& worldPos) {
                         newTower = new LaserTower(worldPos, mProjectiles);
                     else if (mAvailableTowers[0] == 2)
                         newTower = new FlameTurret(worldPos, mProjectiles);
+                    else if (mAvailableTowers[0] == 3)
+                        newTower = new ThunderRod(worldPos, mProjectiles, mEnemies);
                     break;
                 case 1:
-                    if (mAvailableTowers[0] == 1)
+                    if (mAvailableTowers[1] == 1)
                         newTower = new LaserTower(worldPos, mProjectiles);
                     else if (mAvailableTowers[1] == 2)
                         newTower = new FlameTurret(worldPos, mProjectiles);
+                    else if (mAvailableTowers[1] == 3)
+                        newTower = new ThunderRod(worldPos, mProjectiles, mEnemies);
+                    break;
+                case 2:
+                    if (mAvailableTowers[2] == 1)
+                        newTower = new LaserTower(worldPos, mProjectiles);
+                    else if (mAvailableTowers[2] == 2)
+                        newTower = new FlameTurret(worldPos, mProjectiles);
+                    else if (mAvailableTowers[2] == 3)
+                        newTower = new ThunderRod(worldPos, mProjectiles, mEnemies);
                     break;
             }
 
@@ -390,18 +414,12 @@ void GameEngine::update() {
 
             // Update projectiles
             for (auto projectile = mProjectiles.begin(); projectile != mProjectiles.end();) {
-                if (projectile->getTarget() == nullptr) {
-                    projectile = mProjectiles.erase(projectile);
-                    continue;
-                }
                 projectile->update(dt);
 
-                if (projectile->hasHitTarget()) {
-                    projectile->getTarget()->takeDamage(projectile->getDamage());
+                if (projectile->shouldRemove())
                     projectile = mProjectiles.erase(projectile);
-                } else {
+                else
                     ++projectile;
-                }
             }
 
             // Update enemies

--- a/src/TowerDefense/gamengine/GameEngine.cpp
+++ b/src/TowerDefense/gamengine/GameEngine.cpp
@@ -158,30 +158,31 @@ void GameEngine::processEvents() {
                                     int selectedTowerType = mTowerSelectionMenu.getSelectedTowerType(mousePos);
                                     if (selectedTowerType != -1) {
                                         Tower* newTower = nullptr;
+                                        sf::Vector2f position = mTowerSelectionMenu.getCenterPosition();
                                         switch (selectedTowerType) {
                                             case 0: // Laser Tower
                                                 if (mAvailableTowers[0] == 1)
-                                                    newTower = new LaserTower(mousePos, mProjectiles);
+                                                    newTower = new LaserTower(position, mProjectiles);
                                                 else if (mAvailableTowers[0] == 2)
-                                                    newTower = new FlameTurret(mousePos, mProjectiles);
+                                                    newTower = new FlameTurret(position, mProjectiles);
                                                 else if (mAvailableTowers[0] == 3)
-                                                    newTower = new ThunderRod(mousePos, mProjectiles, mEnemies);
+                                                    newTower = new ThunderRod(position, mProjectiles, mEnemies);
                                                 break;
                                             case 1:
                                                 if (mAvailableTowers[1] == 1)
-                                                    newTower = new LaserTower(mousePos, mProjectiles);
+                                                    newTower = new LaserTower(position, mProjectiles);
                                                 else if (mAvailableTowers[1] == 2)
-                                                    newTower = new FlameTurret(mousePos, mProjectiles);
+                                                    newTower = new FlameTurret(position, mProjectiles);
                                                 else if (mAvailableTowers[1] == 3)
-                                                    newTower = new ThunderRod(mousePos, mProjectiles, mEnemies);
+                                                    newTower = new ThunderRod(position, mProjectiles, mEnemies);
                                                 break;
                                             case 2:
                                                 if (mAvailableTowers[2] == 1)
-                                                    newTower = new LaserTower(mousePos, mProjectiles);
+                                                    newTower = new LaserTower(position, mProjectiles);
                                                 else if (mAvailableTowers[2] == 2)
-                                                    newTower = new FlameTurret(mousePos, mProjectiles);
+                                                    newTower = new FlameTurret(position, mProjectiles);
                                                 else if (mAvailableTowers[2] == 3)
-                                                    newTower = new ThunderRod(mousePos, mProjectiles, mEnemies);
+                                                    newTower = new ThunderRod(position, mProjectiles, mEnemies);
                                                 break;
                                         }
 
@@ -274,30 +275,31 @@ void GameEngine::handleNonTowerClick(const sf::Vector2f& worldPos) {
     if (distance(worldPos, mPlayer.getPosition()) <= mPlayer.getPlacementRange()) {
         if (mTowerSelectionMenu.isVisible()) {
             Tower* newTower = nullptr;
+            sf::Vector2f position = mTowerSelectionMenu.getCenterPosition();
             switch (mSelectedTowerType) {
                 case 0:
                     if (mAvailableTowers[0] == 1)
-                        newTower = new LaserTower(worldPos, mProjectiles);
+                        newTower = new LaserTower(position, mProjectiles);
                     else if (mAvailableTowers[0] == 2)
-                        newTower = new FlameTurret(worldPos, mProjectiles);
+                        newTower = new FlameTurret(position, mProjectiles);
                     else if (mAvailableTowers[0] == 3)
-                        newTower = new ThunderRod(worldPos, mProjectiles, mEnemies);
+                        newTower = new ThunderRod(position, mProjectiles, mEnemies);
                     break;
                 case 1:
                     if (mAvailableTowers[1] == 1)
-                        newTower = new LaserTower(worldPos, mProjectiles);
+                        newTower = new LaserTower(position, mProjectiles);
                     else if (mAvailableTowers[1] == 2)
-                        newTower = new FlameTurret(worldPos, mProjectiles);
+                        newTower = new FlameTurret(position, mProjectiles);
                     else if (mAvailableTowers[1] == 3)
-                        newTower = new ThunderRod(worldPos, mProjectiles, mEnemies);
+                        newTower = new ThunderRod(position, mProjectiles, mEnemies);
                     break;
                 case 2:
                     if (mAvailableTowers[2] == 1)
-                        newTower = new LaserTower(worldPos, mProjectiles);
+                        newTower = new LaserTower(position, mProjectiles);
                     else if (mAvailableTowers[2] == 2)
-                        newTower = new FlameTurret(worldPos, mProjectiles);
+                        newTower = new FlameTurret(position, mProjectiles);
                     else if (mAvailableTowers[2] == 3)
-                        newTower = new ThunderRod(worldPos, mProjectiles, mEnemies);
+                        newTower = new ThunderRod(position, mProjectiles, mEnemies);
                     break;
             }
 

--- a/src/TowerDefense/gamengine/GameEngine.h
+++ b/src/TowerDefense/gamengine/GameEngine.h
@@ -9,6 +9,7 @@
 #include "../tower/TowerMenu.h"
 #include "../tower/LaserTower.h"
 #include "../tower/FlameTurret.h"
+#include "../tower/ThunderRod.h"
 #include "../player/Player.h"
 #include "../player/PlayerMenu.h"
 #include "../menues/SmallMenu.h"

--- a/src/TowerDefense/projectiles/Projectile.cpp
+++ b/src/TowerDefense/projectiles/Projectile.cpp
@@ -48,7 +48,7 @@ void Projectile::update(float dt) {
 
         // Check if the projectile has hit the target
         if (!mHitTarget && checkCollision(mTarget)) {
-            //mTarget->takeDamage(mDamage);
+            mTarget->takeDamage(mDamage);
             mHitTarget = true;
         }
     }

--- a/src/TowerDefense/projectiles/Projectile.h
+++ b/src/TowerDefense/projectiles/Projectile.h
@@ -13,6 +13,7 @@ public:
     sf::Vector2f getPosition() const;
     float getDamage() const;
     Enemy* getTarget() const;
+    virtual bool shouldRemove() const {return mHitTarget || !mTarget;};
 
 protected:
     sf::RectangleShape mShape;
@@ -21,7 +22,7 @@ protected:
     float mDamage;
     bool mHitTarget;
     bool mAlive;
-
+ 
     bool checkCollision(const Enemy* target) const;
 };
 

--- a/src/TowerDefense/tower/FlameTurret.cpp
+++ b/src/TowerDefense/tower/FlameTurret.cpp
@@ -7,6 +7,8 @@ static float distance(const sf::Vector2f& a, const sf::Vector2f& b) {
 
 FlameTurret::FlameTurret(const sf::Vector2f& position, std::vector<Projectile>& projectiles)
     : Tower(position, projectiles) {
+
+    mShape.setFillColor(sf::Color(120, 200, 50));
     mRange = 100.0f;
     mFireRate = 2.0f;
     mDamage = 10.0f;
@@ -28,7 +30,7 @@ void FlameTurret::update(float dt, std::vector<Enemy>& enemies) {
             float dist = distance(mShape.getPosition(), enemy.getPosition());
             if (dist <= mRange) {
                 selectedEnemy = &enemy;
-                fireFlame();
+                fireProjectile();
                 mTimeSinceLastShot = 0.0f;
                 break;
             }
@@ -40,7 +42,7 @@ void FlameTurret::update(float dt, std::vector<Enemy>& enemies) {
         mTarget = nullptr;
 }
 
-void FlameTurret::fireFlame() {
+void FlameTurret::fireProjectile() {
     if (!mTarget) return;
 
     // Fire the flame projectile

--- a/src/TowerDefense/tower/FlameTurret.h
+++ b/src/TowerDefense/tower/FlameTurret.h
@@ -11,6 +11,6 @@ public:
     void update(float dt, std::vector<Enemy>& enemies) override;
 
 private:
-    void fireFlame();
+    void fireProjectile() override;
 };
 

--- a/src/TowerDefense/tower/ThunderRod.cpp
+++ b/src/TowerDefense/tower/ThunderRod.cpp
@@ -1,0 +1,22 @@
+#include "ThunderRod.h"
+#include <math.h>
+
+static float distance(const sf::Vector2f& a, const sf::Vector2f& b) {
+    return std::sqrt((a.x - b.x) * (a.x - b.x) + (a.y - b.y) * (a.y - b.y));
+}
+
+ThunderRod::ThunderRod(const sf::Vector2f& position, std::vector<Projectile>& projectiles, std::vector<Enemy>& enemies)
+    : Tower(position, projectiles), mMaxChains(3), mChainRange(100.f), mEnemies(enemies) {
+    mShape.setFillColor(sf::Color::Cyan);
+
+    mRange = 120.0f;
+    mFireRate = 2.25f;
+    mDamage = 14.0f;
+    mCost = 200;
+
+    // mUpgrades.clear();
+    // mUpgrades.push_back(Upgrade("Chain Damage", 200, 5, [this]() { mDamage += 5; }));
+    // mUpgrades.push_back(Upgrade("Chain Range", 150, 10, [this]() { mChainRange += 15.0f; }));
+    // mUpgrades.push_back(Upgrade("Chain Count", 300, 1, [this]() { mMaxChains++; }));
+}
+

--- a/src/TowerDefense/tower/ThunderRod.h
+++ b/src/TowerDefense/tower/ThunderRod.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "Tower.h"
+#include <SFML/Graphics.hpp>
+#include "../enemy/Enemy.h"
+#include "../projectiles/FlameProjectile.h"
+// #include "../projectilehtningProjectile.h"
+
+class ThunderRod : public Tower {
+public:
+    ThunderRod(const sf::Vector2f& position, std::vector<Projectile>& projectiles, std::vector<Enemy>& enemies);
+
+private:
+    int mMaxChains;
+    float mChainRange;
+    std::vector<Enemy>& mEnemies;
+};
+

--- a/src/TowerDefense/tower/Tower.h
+++ b/src/TowerDefense/tower/Tower.h
@@ -50,7 +50,7 @@ protected:
     float mDamage;
     std::vector<Projectile>& mProjectiles;
 
-    void fireProjectile();
+    virtual void fireProjectile();
 
     std::vector<Upgrade> mUpgrades;
 };

--- a/src/TowerDefense/tower/TowerSelectionMenu.cpp
+++ b/src/TowerDefense/tower/TowerSelectionMenu.cpp
@@ -10,6 +10,7 @@ TowerSelectionMenu::TowerSelectionMenu(std::vector<int>& availableTowers)
 
     if (!mFont.loadFromFile("assets/fonts/gameFont.ttf"))
         std::cout << "Couldn't load font2 ffsk" << std::endl;
+
     initializeHexagon();
     initializeLabels();
     initializeStats();
@@ -40,6 +41,8 @@ void TowerSelectionMenu::initializeLabels() {
                 label.setString("Laser");
             else if (mAvailableTowers[i] == 2)
                 label.setString("Flame");
+            else if (mAvailableTowers[i] == 3)
+                label.setString("Thunder");
             else
                 label.setString("");
         } else {
@@ -186,6 +189,8 @@ void TowerSelectionMenu::updateHover(const sf::Vector2f& mousePosition, int crys
                 towerCost = 100;
             else if (mAvailableTowers[i] == 2)
                 towerCost = 150;
+            else if (mAvailableTowers[i] == 3)
+                towerCost = 200;
 
             sf::Color normalColor;
 
@@ -268,8 +273,10 @@ void TowerSelectionMenu::formatStats(int i) {
 
     if (mAvailableTowers[i] == 2)
         mTowerIcon.setFillColor(sf::Color(255, 84, 84, 255));
-    else if(mAvailableTowers[i] == 1)
+    else if (mAvailableTowers[i] == 1)
         mTowerIcon.setFillColor(sf::Color::Green);
+    else if (mAvailableTowers[i] == 3)
+        mTowerIcon.setFillColor(sf::Color::Cyan);
 }
 
 bool TowerSelectionMenu::isPointInConvexShape(const sf::ConvexShape& shape, const sf::Vector2f& point) const {

--- a/src/TowerDefense/tower/TowerSelectionMenu.cpp
+++ b/src/TowerDefense/tower/TowerSelectionMenu.cpp
@@ -219,6 +219,11 @@ void TowerSelectionMenu::updateHover(const sf::Vector2f& mousePosition, int crys
     }
 }
 
+sf::Vector2f TowerSelectionMenu::getCenterPosition() const {
+    // Hardcoded value for the tower radius, will modify later when tower sprites are introduced
+    return mPosition - sf::Vector2f(15.f, 15.f);
+}
+
 void TowerSelectionMenu::drawLines(sf::RenderWindow& window) const {
     sf::VertexArray lines(sf::Lines, 12);
 

--- a/src/TowerDefense/tower/TowerSelectionMenu.h
+++ b/src/TowerDefense/tower/TowerSelectionMenu.h
@@ -14,6 +14,7 @@ public:
     int getSelectedTowerType(const sf::Vector2f& point) const;
     bool isInsideMenu(const sf::Vector2f& point) const;
     void updateHover(const sf::Vector2f& mousePosition, int crystals);
+    sf::Vector2f getCenterPosition() const;
 
 private:
     sf::ConvexShape mHexagon;


### PR DESCRIPTION
## **Title** 
[#46] Fix tower placement

## **Description**  
**What changes did you make?**  
Made towers being placed at the center of the `TowerSelectionMenu`

**Why are these changes needed?**   
Improves player accuracy and strategic play in the tower defense mode.

**Related Issue:**  
Fixes #46 

## **Type of Change**  
- [x] Bug fix 
- [ ] New feature
- [ ] Code Refactor
- [ ]  Documentation update 

## **Checklist**  
- [x] **Self-Review**: I checked my own changes for mistakes.    
- [ ] **Docs**: Updated documentation if required.  
- [x] **Zero Warnings**: Changes don’t introduce new compiler/linter warnings.

