### PR TITLE
Improve MainMenu to RPG transition

### DIFF
--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -81,6 +81,7 @@ void GameManager::switchToRPG(int crystals) {
 // Used for transition between MainMenu and RPG
 void GameManager::enterRPG(int saveNumber) {
     mRpgEngine.setSaveNumber(saveNumber);
+    mRpgEngine.closeMenues();
     mCurrentState = GameState::RPG;
 }
 

--- a/src/Rpg/gamengine/RPGEngine.cpp
+++ b/src/Rpg/gamengine/RPGEngine.cpp
@@ -669,9 +669,12 @@ void RPGEngine::renderDateTime(sf::RenderWindow& window, sf::Font& font, const s
 }
 
 void RPGEngine::resume(int crystals) {
-    mWindow.setView(mWindow.getDefaultView());
     mCrystals = crystals;
+    closeMenues();
+}
 
+void RPGEngine::closeMenues() {
+    mWindow.setView(mWindow.getDefaultView());
     if (mShowDialogue)
         mShowDialogue = false;
         mNPCManager.resumeCurrentNPC();

--- a/src/Rpg/gamengine/RPGEngine.h
+++ b/src/Rpg/gamengine/RPGEngine.h
@@ -43,6 +43,7 @@ public:
     void render();
     void renderDateTime(sf::RenderWindow& window, sf::Font& font, const std::string& date, const std::string& time);
     void resume(int crystals);
+    void closeMenues();
 
     void saveGame();
     void loadGame();


### PR DESCRIPTION
## **Title** 
Improve MainMenu to RPG transition

## **Description**  
**What changes did you make?**  
Add close menu function to close all menues on RPG transition.

**Why are these changes needed?**   
When going back to the `MainMenu` and trying to enter `RPG` the menu was still showing from the last session.

## **Type of Change**  
- [ ] Bug fix 
- [ ] New feature
- [x] Code Refactor
- [ ]  Documentation update 

## **Checklist**  
- [x] **Self-Review**: I checked my own changes for mistakes.    
- [ ] **Docs**: Updated documentation if required.  
- [x]  **Zero Warnings**: Changes don’t introduce new compiler/linter warnings.

