### PR TITLE
Refactor item copying to use clone() instead of manual instantiation

### DIFF
--- a/src/Rpg/inventory/Inventory.h
+++ b/src/Rpg/inventory/Inventory.h
@@ -20,13 +20,13 @@ public:
     int getSlotCount() const;
     void resize(int newRows, int newCols);
     void removeItemAt(int slotIndex);
+    int getFirstEmptySlot() const;
 
 private:
     std::vector<InventoryItem> mSlots;
     int mRows;
     int mCols;
 
-    int getFirstEmptySlot() const;
     int findSlotWithItem(int id) const;
 };
 

--- a/src/Rpg/inventory/items/Item.h
+++ b/src/Rpg/inventory/items/Item.h
@@ -1,12 +1,14 @@
 #pragma once
 #include <SFML/Graphics.hpp>
 #include <string>
+#include <memory>
 
 class Item {
 public:
     Item(const std::string& name, const std::string& description, int id, int price, const sf::RectangleShape& icon);
     virtual ~Item() = default;
     virtual std::string getType() const = 0;
+    virtual std::unique_ptr<Item> clone() const = 0;
 
     const std::string& getName() const;
     const std::string& getDescription() const;

--- a/src/Rpg/inventory/items/TowerBlueprint.h
+++ b/src/Rpg/inventory/items/TowerBlueprint.h
@@ -5,5 +5,8 @@ class TowerBlueprint : public Item {
 public:
     TowerBlueprint();
     std::string getType() const override;
+    std::unique_ptr<Item> clone() const override {
+        return std::make_unique<TowerBlueprint>(*this);
+    };
 };
 

--- a/src/Rpg/inventory/items/TowerBlueprintEpic.h
+++ b/src/Rpg/inventory/items/TowerBlueprintEpic.h
@@ -5,5 +5,8 @@ class TowerBlueprintEpic : public Item {
 public:
     TowerBlueprintEpic();
     std::string getType() const override;
+    std::unique_ptr<Item> clone() const override {
+        return std::make_unique<TowerBlueprintEpic>(*this);
+    };
 };
 

--- a/src/Rpg/inventory/items/TowerBlueprintMythic.h
+++ b/src/Rpg/inventory/items/TowerBlueprintMythic.h
@@ -5,5 +5,8 @@ class TowerBlueprintMythic : public Item {
 public:
     TowerBlueprintMythic();
     std::string getType() const override;
+    std::unique_ptr<Item> clone() const override {
+        return std::make_unique<TowerBlueprintMythic>(*this);
+    };
 };
 

--- a/src/Rpg/inventory/items/TowerBlueprintRare.h
+++ b/src/Rpg/inventory/items/TowerBlueprintRare.h
@@ -5,5 +5,8 @@ class TowerBlueprintRare : public Item {
 public:
     TowerBlueprintRare();
     std::string getType() const override;
+    std::unique_ptr<Item> clone() const override {
+        return std::make_unique<TowerBlueprintRare>(*this);
+    };
 };
 

--- a/src/Rpg/inventory/items/Wood.h
+++ b/src/Rpg/inventory/items/Wood.h
@@ -5,5 +5,8 @@ class Wood : public Item {
 public:
     Wood();
     std::string getType() const override;
+    std::unique_ptr<Item> clone() const override {
+        return std::make_unique<Wood>(*this);
+    };
 };
 

--- a/src/Rpg/menues/AnalyzeMenu.cpp
+++ b/src/Rpg/menues/AnalyzeMenu.cpp
@@ -254,19 +254,7 @@ void AnalyzeMenu::handleMouseClick(const sf::Vector2f& mousePos) {
 
         if (mousePos.x >= mSlot.getPosition().x && mousePos.x <= mSlot.getPosition().x + mSlot.getSize().x &&
             mousePos.y >= mSlot.getPosition().y && mousePos.y <= mSlot.getPosition().y + mSlot.getSize().y) {
-            if (mSlotItem->getId() == 2) {
-                std::unique_ptr<TowerBlueprint> towerB = std::make_unique<TowerBlueprint>();
-                mInventory.addItem(std::move(towerB), 1);
-            } else if (mSlotItem->getId() == 3) {
-                std::unique_ptr<TowerBlueprintRare> towerBR = std::make_unique<TowerBlueprintRare>();
-                mInventory.addItem(std::move(towerBR), 1);
-            } else if (mSlotItem->getId() == 4) {
-                std::unique_ptr<TowerBlueprintEpic> towerBE = std::make_unique<TowerBlueprintEpic>();
-                mInventory.addItem(std::move(towerBE), 1);
-            } else if (mSlotItem->getId() == 5) {
-                std::unique_ptr<TowerBlueprintMythic> towerBM = std::make_unique<TowerBlueprintMythic>();
-                mInventory.addItem(std::move(towerBM), 1);
-            }
+            mInventory.addItem(mSlotItem->clone(), 1);
             mSlotItem = nullptr;
             mInSlot = false;
             mCompleted = false;
@@ -288,21 +276,10 @@ void AnalyzeMenu::handleMouseClick(const sf::Vector2f& mousePos) {
                 mInventory.getItemAt(hoveredSlot)->getId() == 4 ||
                 mInventory.getItemAt(hoveredSlot)->getId() == 5) {
                 if (mInventory.getItemQuantityAt(hoveredSlot) == 1) {
-                    // if it is the last tower blueprint of the kind the removeItemAt call makes the pointer nullptr
-                    // so const_char<Item*> didnt work, tried by new Item(*mInventory.getItemAt(hoveredSlot))
-                    // Item is an abstract class so I cant directly instantiate itemChance
-                    // maybe will add a clone method to the Item class in the future
-                    if (mInventory.getItemAt(hoveredSlot)->getId() == 2)
-                        mSlotItem = new TowerBlueprint();
-                    else if(mInventory.getItemAt(hoveredSlot)->getId() == 3)
-                        mSlotItem = new TowerBlueprintRare();
-                    else if(mInventory.getItemAt(hoveredSlot)->getId() == 4)
-                        mSlotItem = new TowerBlueprintEpic();
-                    else if(mInventory.getItemAt(hoveredSlot)->getId() == 5)
-                        mSlotItem = new TowerBlueprintMythic();
+                    mSlotItem = mInventory.getItemAt(hoveredSlot)->clone().release();
                     mInventory.removeItemAt(hoveredSlot);
                 } else {
-                    mSlotItem = const_cast<Item*>(mInventory.getItemAt(hoveredSlot));
+                    mSlotItem = mInventory.getItemAt(hoveredSlot)->clone().release();
                     mInventory.setItemQuantityAt(hoveredSlot, mInventory.getItemQuantityAt(hoveredSlot) - 1);
                 }
                 mInSlot = true;


### PR DESCRIPTION
## **Title** 
Refactor item copying to use `clone()` instead of manual instantiation

## **Description**  
**What changes did you make?**  
Added a `clone()` method to the Item class to allow copying items.

**Why are these changes needed?**   
Removes repetitive `if-else` chains when creating items.
New items can be copied without modifying inventory logic.

## **Type of Change**  
- [ ] Bug fix 
- [x] New feature
- [ ] Code Refactor
- [ ]  Documentation update 

## **Checklist**  
- [x] **Self-Review**: I checked my own changes for mistakes.    
- [ ] **Docs**: Updated documentation if required.  
- [x] **Zero Warnings**: Changes don’t introduce new compiler/linter warnings.

