### PR TITLE
[#25] Solve wave restart problem

### DIFF
--- a/src/TowerDefense/gamengine/GameEngine.cpp
+++ b/src/TowerDefense/gamengine/GameEngine.cpp
@@ -24,7 +24,7 @@ GameEngine::GameEngine(sf::RenderWindow& window, GameManager* gameManager)
     mTowerMenu(),
     mTowerSelectionMenu(mAvailableTowers),
     mCrystals(100),
-    mSpentCrystals(0),
+    mInitialCrystals(0),
     mPlayer(sf::Vector2f(100, 100), mProjectiles),
     mPlayerMenu(),
     gameStarted(false),
@@ -35,7 +35,7 @@ GameEngine::GameEngine(sf::RenderWindow& window, GameManager* gameManager)
     mShowText1(false),
     mShowText2(false),
     mGameManager(gameManager),
-    mSmallMenu(mWindow, this, gameManager, mCurrentLevel, mCrystals, mSpentCrystals, mAvailableTowers),
+    mSmallMenu(mWindow, this, gameManager, mCurrentLevel, mAvailableTowers),
     mLevelCompleteMenu(mWindow, this, gameManager, mCurrentLevel),
     mGameOverMenu(mWindow, this, gameManager, mCurrentLevel, mCrystals, mAvailableTowers) {
 
@@ -196,7 +196,6 @@ void GameEngine::processEvents() {
                                             if (mCrystals >= newTower->getCost()) {
                                                 mTowers.push_back(newTower);
                                                 mCrystals -= newTower->getCost();
-                                                mSpentCrystals += newTower->getCost();
                                                 mTowerSelectionMenu.hide();
                                                 mSelectedTowerType = -1;
                                             } else {
@@ -318,7 +317,6 @@ void GameEngine::handleNonTowerClick(const sf::Vector2f& worldPos) {
                     std::cout << "Placing tower at: " << worldPos.x << ", " << worldPos.y << std::endl;
                     mTowers.push_back(newTower);
                     mCrystals -= newTower->getCost();
-                    mSpentCrystals += newTower->getCost();
                     mTowerSelectionMenu.hide();
                 } else {
                     mNotEnoughCrystalsText.setPosition(sf::Vector2f(position.x - 104.35f, position.y - 81.f));
@@ -605,11 +603,12 @@ void GameEngine::init(int level, int crystals, const std::vector<int>& available
 
     // Reset all variables and states to their initial values for the specified level
     mCrystals = crystals;
-    mSpentCrystals = 0;
+    mInitialCrystals = crystals;
     mTowers.clear();
     mEnemies.clear();
     mProjectiles.clear();
     mCurrentWaveNumber = 1;
+    mCurrentWave = Wave(level, mCurrentWaveNumber, { 0 });
     mTowerHealth = 100;
     gameStarted = false;
     mGameOver = false;
@@ -625,6 +624,7 @@ void GameEngine::init(int level, int crystals, const std::vector<int>& available
     mWindow.setView(mWindow.getDefaultView());
 
     mPlayer.setPosition(sf::Vector2f(100, 100));
+    mPlayer.setAnimation(4);
 }
 
 bool GameEngine::isLevelCompleted(int level) const {
@@ -641,3 +641,6 @@ int GameEngine::getCrystals() const {
     return mCrystals;
 }
 
+int GameEngine::getInitialCrystals() {
+    return mInitialCrystals;
+}

--- a/src/TowerDefense/gamengine/GameEngine.h
+++ b/src/TowerDefense/gamengine/GameEngine.h
@@ -32,6 +32,7 @@ public:
     void init(int level, int crytals, const std::vector<int>& availableTowers);
     bool isLevelCompleted(int level) const;
     int getCrystals() const;
+    int getInitialCrystals();
 
 private:
 
@@ -61,7 +62,7 @@ private:
     sf::Text mCrystalText;
     sf::Font mFont;
     int mCrystals;
-    int mSpentCrystals;
+    int mInitialCrystals;
 
     Tower* mSelectedTower;
 

--- a/src/TowerDefense/menues/SmallMenu.cpp
+++ b/src/TowerDefense/menues/SmallMenu.cpp
@@ -3,31 +3,34 @@
 #include "../../GameManager.h"
 #include <iostream>
 
-SmallMenu::SmallMenu(sf::RenderWindow& window, GameEngine* game, GameManager* gameManager, int level,
-                     int& crystals, int& spentCrystals, std::vector<int>& availableTowers)
+SmallMenu::SmallMenu(sf::RenderWindow& window, GameEngine* game, GameManager* gameManager,
+                     int level, std::vector<int>& availableTowers)
     : mIsVisible(false), mGame(game), mGameManager(gameManager), mAvailableTowers(availableTowers),
     quitButton(sf::Vector2f(0, 0), sf::Vector2f(175, 40), "Quit"),
-    restartButton(sf::Vector2f(0, 0), sf::Vector2f(175, 40), "Restart"), mLevel(level),
-    mCrystals(crystals), mSpentCrystals(spentCrystals) {
+    restartButton(sf::Vector2f(0, 0), sf::Vector2f(175, 40), "Restart"), mLevel(level) {
 
     mMenuBackground.setSize(sf::Vector2f(270, 140));
     mMenuBackground.setFillColor(sf::Color(50, 50, 50, 220));
     mMenuBackground.setPosition((window.getSize().x - mMenuBackground.getSize().x) / 2,
                                 (window.getSize().y - mMenuBackground.getSize().y) / 2);
 
+    mBackground.setSize(sf::Vector2f(window.getSize().x, window.getSize().y));
+    mBackground.setFillColor(sf::Color(50, 50, 50, 185));
+    mBackground.setPosition(sf::Vector2f(0, 0));
+
     quitButton.setPosition(sf::Vector2f(mMenuBackground.getPosition().x + 45, mMenuBackground.getPosition().y + 77));
     restartButton.setPosition(sf::Vector2f(mMenuBackground.getPosition().x + 45, mMenuBackground.getPosition().y + 25));
 
-    quitButton.setCallback([&]() {
+    quitButton.setCallback([this, game, gameManager]() {
         if (mGameManager)
-            mGameManager->switchToRPG((mCrystals + mSpentCrystals) * 6 / 7);
+            mGameManager->switchToRPG(game->getInitialCrystals() * 6 / 7);
         else
             std::cerr << "Error: GameManager is nullptr in returnButton callback." << std::endl;
     });
 
-    restartButton.setCallback([this]() {
+    restartButton.setCallback([this, game]() {
         if (mGame)
-            mGame->init(mLevel, mCrystals + mSpentCrystals, mAvailableTowers);
+            mGame->init(mLevel, game->getInitialCrystals(), mAvailableTowers);
         else
             std::cerr << "Error: Game is nullptr in restartButton callback." << std::endl;
     });
@@ -40,6 +43,7 @@ SmallMenu::SmallMenu(sf::RenderWindow& window, GameEngine* game, GameManager* ga
 void SmallMenu::render(sf::RenderWindow& window) {
     if (!mIsVisible) return;
 
+    window.draw(mBackground);
     window.draw(mMenuBackground);
     for (auto& button : mButtons)
         button.render(window);

--- a/src/TowerDefense/menues/SmallMenu.h
+++ b/src/TowerDefense/menues/SmallMenu.h
@@ -8,8 +8,8 @@ class GameManager;
 
 class SmallMenu {
 public:
-    SmallMenu(sf::RenderWindow& window, GameEngine* game, GameManager* gameManager, int level,
-              int& crystals, int& spentCrystals, std::vector<int>& availableTowers);
+    SmallMenu(sf::RenderWindow& window, GameEngine* game, GameManager* gameManager,
+              int level, std::vector<int>& availableTowers);
 
     void render(sf::RenderWindow& window);
     void handleMouseClick(const sf::Vector2f& mousePos);
@@ -21,6 +21,7 @@ public:
 
 private:
     sf::RectangleShape mMenuBackground;
+    sf::RectangleShape mBackground;
 
     std::vector<Button> mButtons;
     Button quitButton;
@@ -29,8 +30,6 @@ private:
     GameEngine* mGame;
     GameManager* mGameManager;
     int mLevel;
-    int& mCrystals;
-    int& mSpentCrystals;
     bool mIsVisible;
 
     std::vector<int>& mAvailableTowers;

--- a/src/TowerDefense/player/Player.cpp
+++ b/src/TowerDefense/player/Player.cpp
@@ -229,3 +229,22 @@ void Player::setHealth(float health) {
     mHealth = health;
 }
 
+
+void Player::setAnimation(int animation) {
+    if (animation == 4) {
+        mLastDirection = sf::Keyboard::S;
+        mCurrentAnimation = AnimationIndex::IdleDown;
+    } else if (animation == 3) {
+        mLastDirection = sf::Keyboard::W;
+        mCurrentAnimation = AnimationIndex::IdleUp;
+    } else if (animation == 2) {
+        mLastDirection = sf::Keyboard::D;
+        mCurrentAnimation = AnimationIndex::IdleRight;
+    } else if (animation == 1) {
+        mLastDirection = sf::Keyboard::A;
+        mCurrentAnimation = AnimationIndex::IdleLeft;
+    }
+
+    mAnimations[int(mCurrentAnimation)].applyToSprite(mSprite);
+}
+

--- a/src/TowerDefense/player/Player.h
+++ b/src/TowerDefense/player/Player.h
@@ -24,6 +24,7 @@ public:
     void takeDamage(float amount);
     float getHealth() const;
     void setHealth(float health);
+    void setAnimation(int animation);
 
     sf::FloatRect getBounds() const;
     void setPosition(const sf::Vector2f& position);


### PR DESCRIPTION
## **Title** 
[#25] Solve wave restart problem

## **Description**  
**What changes did you make?**  
Improved tower defense menu restart and quit methods and solved the wave restart problem.

**Why are these changes needed?**   
When waves were restarted the game didn't start from wave 1.

**Related Issue:**  
Fixes #25 

## **Type of Change**  
- [ ] Bug fix 
- [x] New feature
- [ ] Code Refactor
- [ ]  Documentation update 

## **Checklist**  
- [x] **Self-Review**: I checked my own changes for mistakes.    
- [ ] **Docs**: Updated documentation if required.  
- [x] **Zero Warnings**: Changes don’t introduce new compiler/linter warnings.

