### PR TITLE
[#79] Add player profile in `InventoryMenu`

### DIFF
--- a/src/Rpg/gamengine/RPGEngine.cpp
+++ b/src/Rpg/gamengine/RPGEngine.cpp
@@ -593,7 +593,7 @@ void RPGEngine::render() {
         dialogueBox.setPosition((mWindow.getSize().x - dialogueBox.getSize().x) / 2 - 60.f,
             mWindow.getSize().y - dialogueBox.getSize().y - 35.0f);
 
-        sf::Sprite npcSprite = mCurrentInteractingNPC->getSprite();
+        sf::Sprite npcSprite = mCurrentInteractingNPC->getIconSprite();
         npcSprite.setPosition(dialogueBox.getPosition().x - 21.f,
             dialogueBox.getPosition().y + 37.5f);
         separationLine.setPosition({dialogueBox.getPosition().x + 140.f, dialogueBox.getPosition().y});
@@ -1164,14 +1164,6 @@ void RPGEngine::uninitialize() {
     mIsInitialized = false;
 }
 
-SaveSystem& RPGEngine::getSaveSystem() {
-    return mSaveSystem;
-}
-
-Inventory& RPGEngine::getInventory() {
-    return mInventory;
-}
-
 sf::Vector2f RPGEngine::calculateDropPosition() {
     sf::FloatRect playerBounds = mCharacter.getBounds();
     sf::Vector2f startPos = {playerBounds.left + playerBounds.width / 2.f, playerBounds.top + playerBounds.height / 2.f};
@@ -1225,3 +1217,14 @@ void RPGEngine::advanceTowerDefenseLevel() {
     mStartTowerDefenseMenu.advanceLevel();
 }
 
+SaveSystem& RPGEngine::getSaveSystem() {
+    return mSaveSystem;
+}
+
+Inventory& RPGEngine::getInventory() {
+    return mInventory;
+}
+
+MainCharacter& RPGEngine::getPlayer() {
+    return mCharacter;
+}

--- a/src/Rpg/gamengine/RPGEngine.cpp
+++ b/src/Rpg/gamengine/RPGEngine.cpp
@@ -65,7 +65,7 @@ RPGEngine::RPGEngine(sf::RenderWindow& window, GameManager* gameManager)
     mChestInventory(2, 2),
     mCurrentInteractingNPC(nullptr),
     mSkillTree(),
-    mMenu(window, mSkillTree, mInventory, mCharacter.getPosition(), mDroppedItems, *this, gameManager),
+    mMenu(window, mSkillTree, mInventory, *this, gameManager),
     mHotbar(mInventory, sf::Vector2f(mWindow.getSize().x / 2 - 45.f * 3 / 2, mWindow.getSize().y - 45.f - 4.f),
         mInventory.getSlotCount() / 2, sf::Vector2f(45.f, 45.f)),
     mShowMenu(false),

--- a/src/Rpg/gamengine/RPGEngine.h
+++ b/src/Rpg/gamengine/RPGEngine.h
@@ -72,6 +72,7 @@ public:
 
     SaveSystem& getSaveSystem();
     Inventory& getInventory();
+    MainCharacter& getPlayer();
 
 private:
     sf::RenderWindow& mWindow;

--- a/src/Rpg/inventory/Inventory.cpp
+++ b/src/Rpg/inventory/Inventory.cpp
@@ -47,10 +47,6 @@ void Inventory::setItemQuantityAt(int slot, int quantity) {
         mSlots[slot].quantity = quantity;
 }
 
-int Inventory::getSlotCount() const {
-    return mRows * mCols;
-}
-
 void Inventory::resize(int newRows, int newCols) {
     mRows = newRows;
     mCols = newCols;
@@ -92,3 +88,14 @@ void Inventory::clear() {
     mSlots.resize(mRows * mCols);
 }
 
+int Inventory::getSlotCount() const {
+    return mRows * mCols;
+}
+
+int Inventory::getRows() const {
+    return mRows;
+}
+
+int Inventory::getCols() const {
+    return mCols;
+}

--- a/src/Rpg/inventory/Inventory.h
+++ b/src/Rpg/inventory/Inventory.h
@@ -15,13 +15,19 @@ public:
     void addItem(std::unique_ptr<Item> item, int quantity);
     void swapItems(int slot1, int slot2);
     std::unique_ptr<Item> extractItemAt(int slotIndex);
+
     int getItemQuantityAt(int slot) const;
     void setItemQuantityAt(int slot, int quantity);
+
     const Item* getItemAt(int slot) const;
     int getSlotCount() const;
+    int getRows() const;
+    int getCols() const;
+
     void resize(int newRows, int newCols);
     void removeItemAt(int slotIndex);
     void removeItemById(int id, int quantity);
+
     int getFirstEmptySlot() const;
     void clear();
 

--- a/src/Rpg/inventory/InventoryMenu.cpp
+++ b/src/Rpg/inventory/InventoryMenu.cpp
@@ -1,15 +1,19 @@
 #include "InventoryMenu.h"
 #include <iostream>
+#include <string>
 
 InventoryMenu::InventoryMenu(Inventory& inventory, const sf::Vector2f& position,
         MainCharacter& character, const sf::Vector2f& slotSize)
     : mCharacter(character), mInventory(inventory), mPosition(position),
-    mSlotSize(slotSize), mGap(mSlotSize.x * 3.f), mHoveredSlot(-1), mDraggedSlot(-1), mCharacterSprite(mCharacter.getIconSprite()) {
+    mSlotSize(slotSize), mGap(mSlotSize.x * 1.5f), mHoveredSlot(-1), mDraggedSlot(-1), mCharacterSprite(mCharacter.getIconSprite()) {
 
     int totalSlots = mInventory.getSlotCount();
     mSlots.resize(totalSlots);
 
-    float width = mCharacterSprite.getLocalBounds().width + mInventory.getCols() * mSlotSize.x + mGap;
+    sf::FloatRect spriteBounds = mCharacterSprite.getGlobalBounds();
+    float width = spriteBounds.width + mInventory.getCols() * mSlotSize.x + mGap;
+    mCharacterSprite.setPosition(sf::Vector2f(mPosition.x - width / 2.f, mPosition.y - 21.f));
+
     for (int i = 0; i < totalSlots; ++i) {
         mSlots[i].setSize(slotSize);
         mSlots[i].setFillColor(sf::Color(0, 0, 0, 220));
@@ -17,11 +21,36 @@ InventoryMenu::InventoryMenu(Inventory& inventory, const sf::Vector2f& position,
         mSlots[i].setOutlineThickness(2.0f);
         int row = i / mInventory.getCols();
         int col = i % mInventory.getCols();
-        mSlots[i].setPosition(mPosition.x - width / 2.f + col * slotSize.x + mCharacterSprite.getLocalBounds().width + mGap, mPosition.y + row * slotSize.y);
+        mSlots[i].setPosition(mPosition.x - width / 2.f + col * slotSize.x + spriteBounds.width + mGap, mPosition.y + row * slotSize.y);
     }
 
     if (!mFont.loadFromFile("assets/fonts/gameFont.ttf"))
         std::cout << "Failed to load font in the inventory menu!";
+
+    mLevelText.setFont(mFont);
+    mLevelText.setCharacterSize(15);
+    mLevelText.setFillColor(sf::Color::White);
+    mLevelText.setString("Level 1");
+    mLevelText.setPosition(mCharacterSprite.getPosition().x + (spriteBounds.width - mLevelText.getLocalBounds().width) / 2.f,
+                           mCharacterSprite.getPosition().y + spriteBounds.height * 1.2f);
+
+    mXpBar.setSize(sf::Vector2f(spriteBounds.width / 1.5f, 12.f));
+    mXpBar.setPosition(sf::Vector2f(mCharacterSprite.getPosition().x + (spriteBounds.width - mXpBar.getSize().x) / 2.f,
+                                    mLevelText.getPosition().y + mLevelText.getLocalBounds().height + 15.f));
+    mXpBar.setFillColor(sf::Color(50, 50, 50, 200));
+    mXpBar.setOutlineColor(sf::Color::White);
+    mXpBar.setOutlineThickness(1.f);
+
+    mXpBarFill.setSize(sf::Vector2f(0.f, 12.f));
+    mXpBarFill.setPosition(mXpBar.getPosition());
+    mXpBarFill.setFillColor(sf::Color::Cyan);
+
+    mXpText.setFont(mFont);
+    mXpText.setCharacterSize(12);
+    mXpText.setFillColor(sf::Color::White);
+    mXpText.setString("0 / 50");
+    mXpText.setPosition(mCharacterSprite.getPosition().x + (spriteBounds.width - mXpText.getLocalBounds().width) / 2.f,
+                        mXpBar.getPosition().y + 20.f);
 
     mTooltipText.setFont(mFont);
     mTooltipText.setCharacterSize(14);
@@ -30,8 +59,6 @@ InventoryMenu::InventoryMenu(Inventory& inventory, const sf::Vector2f& position,
     mTooltipBackground.setFillColor(sf::Color(50, 50, 50, 200));
     mTooltipBackground.setOutlineColor(sf::Color::White);
     mTooltipBackground.setOutlineThickness(1.0f);
-
-    mCharacterSprite.setPosition(sf::Vector2f(mPosition.x - width / 2.f, mPosition.y));
 }
 
 void InventoryMenu::render(sf::RenderWindow& window) {
@@ -48,6 +75,13 @@ void InventoryMenu::render(sf::RenderWindow& window) {
         }
     }
 
+    window.draw(mCharacterSprite);
+
+    window.draw(mLevelText);
+    window.draw(mXpText);
+    window.draw(mXpBar);
+    window.draw(mXpBarFill);
+
     if (mHoveredSlot != -1) {
         const Item* item = mInventory.getItemAt(mHoveredSlot);
         if (item) {
@@ -55,8 +89,6 @@ void InventoryMenu::render(sf::RenderWindow& window) {
             window.draw(mTooltipText);
         }
     }
-
-    window.draw(mCharacterSprite);
 }
 
 void InventoryMenu::updateHover(const sf::Vector2f& mousePos) {
@@ -93,13 +125,24 @@ void InventoryMenu::update() {
     if (static_cast<int>(mSlots.size()) != totalSlots)
         mSlots.resize(totalSlots);
 
-    float width = mCharacterSprite.getLocalBounds().width + mInventory.getCols() * mSlotSize.x + mGap;
+    sf::FloatRect spriteBounds = mCharacterSprite.getGlobalBounds();
+    float width = spriteBounds.width + mInventory.getCols() * mSlotSize.x + mGap;
     for (int i = 0; i < totalSlots; ++i) {
         int row = i / mInventory.getCols();
         int col = i % mInventory.getCols();
-        mSlots[i].setPosition(mPosition.x - width / 2.f + col * mSlotSize.x + mCharacterSprite.getLocalBounds().width + mGap,
+        mSlots[i].setPosition(mPosition.x - width / 2.f + col * mSlotSize.x + spriteBounds.width + mGap,
                               mPosition.y + row * mSlotSize.y);
     }
+
+    mLevelText.setString("Level " + std::to_string(mCharacter.getLevel()));
+    mLevelText.setPosition(mCharacterSprite.getPosition().x + (spriteBounds.width - mLevelText.getLocalBounds().width) / 2.f,
+                           mCharacterSprite.getPosition().y + spriteBounds.height * 1.2f);
+
+    mXpText.setString(std::to_string(mCharacter.getXp()) + " / " + std::to_string(mCharacter.getXpForNextLevel()));
+    mXpText.setPosition(mCharacterSprite.getPosition().x + (spriteBounds.width - mXpText.getLocalBounds().width) / 2.f,
+                        mXpBar.getPosition().y + mXpBar.getSize().y + 15.f);
+
+    mXpBarFill.setSize(sf::Vector2f(mXpBar.getSize().x * mCharacter.getXpPercentage(), mXpBar.getSize().y));
 }
 
 int InventoryMenu::getHoveredSlot() const {

--- a/src/Rpg/inventory/InventoryMenu.cpp
+++ b/src/Rpg/inventory/InventoryMenu.cpp
@@ -1,20 +1,23 @@
 #include "InventoryMenu.h"
 #include <iostream>
 
-InventoryMenu::InventoryMenu(Inventory& inventory, const sf::Vector2f& position, MainCharacter& character,
-    const sf::Vector2f& slotSize, const sf::Vector2f& playerPos, std::vector<DroppedItem>& droppedItems)
-    : mCharacter(character), mInventory(inventory), mPosition(position), mSlotSize(slotSize),
-    mHoveredSlot(-1), mDraggedSlot(-1), mPlayerPos(playerPos), mDroppedItems(droppedItems) {
+InventoryMenu::InventoryMenu(Inventory& inventory, const sf::Vector2f& position,
+        MainCharacter& character, const sf::Vector2f& slotSize)
+    : mCharacter(character), mInventory(inventory), mPosition(position),
+    mSlotSize(slotSize), mGap(mSlotSize.x * 3.f), mHoveredSlot(-1), mDraggedSlot(-1), mCharacterSprite(mCharacter.getIconSprite()) {
+
     int totalSlots = mInventory.getSlotCount();
     mSlots.resize(totalSlots);
+
+    float width = mCharacterSprite.getLocalBounds().width + mInventory.getCols() * mSlotSize.x + mGap;
     for (int i = 0; i < totalSlots; ++i) {
         mSlots[i].setSize(slotSize);
         mSlots[i].setFillColor(sf::Color(0, 0, 0, 220));
         mSlots[i].setOutlineColor(sf::Color::White);
         mSlots[i].setOutlineThickness(2.0f);
-        int row = i / 3;
-        int col = i % 3;
-        mSlots[i].setPosition(mPosition.x + col * slotSize.x, mPosition.y + row * slotSize.y);
+        int row = i / mInventory.getCols();
+        int col = i % mInventory.getCols();
+        mSlots[i].setPosition(mPosition.x - width / 2.f + col * slotSize.x + mCharacterSprite.getLocalBounds().width + mGap, mPosition.y + row * slotSize.y);
     }
 
     if (!mFont.loadFromFile("assets/fonts/gameFont.ttf"))
@@ -27,6 +30,8 @@ InventoryMenu::InventoryMenu(Inventory& inventory, const sf::Vector2f& position,
     mTooltipBackground.setFillColor(sf::Color(50, 50, 50, 200));
     mTooltipBackground.setOutlineColor(sf::Color::White);
     mTooltipBackground.setOutlineThickness(1.0f);
+
+    mCharacterSprite.setPosition(sf::Vector2f(mPosition.x - width / 2.f, mPosition.y));
 }
 
 void InventoryMenu::render(sf::RenderWindow& window) {
@@ -51,9 +56,7 @@ void InventoryMenu::render(sf::RenderWindow& window) {
         }
     }
 
-    sf::Sprite characterSprite = mCharacter.getIconSprite();
-    characterSprite.setPosition(sf::Vector2f(mPosition.x - mSlotSize.x * 3.6f, mPosition.y));
-    window.draw(characterSprite);
+    window.draw(mCharacterSprite);
 }
 
 void InventoryMenu::updateHover(const sf::Vector2f& mousePos) {
@@ -86,13 +89,15 @@ void InventoryMenu::handleDragAndDrop(const sf::Vector2f& mousePos) {
 
 void InventoryMenu::update() {
     int totalSlots = mInventory.getSlotCount();
+
     if (static_cast<int>(mSlots.size()) != totalSlots)
         mSlots.resize(totalSlots);
 
+    float width = mCharacterSprite.getLocalBounds().width + mInventory.getCols() * mSlotSize.x + mGap;
     for (int i = 0; i < totalSlots; ++i) {
-        int row = i / 3;
-        int col = i % 3;
-        mSlots[i].setPosition(mPosition.x + col * mSlotSize.x,
+        int row = i / mInventory.getCols();
+        int col = i % mInventory.getCols();
+        mSlots[i].setPosition(mPosition.x - width / 2.f + col * mSlotSize.x + mCharacterSprite.getLocalBounds().width + mGap,
                               mPosition.y + row * mSlotSize.y);
     }
 }

--- a/src/Rpg/inventory/InventoryMenu.cpp
+++ b/src/Rpg/inventory/InventoryMenu.cpp
@@ -1,10 +1,10 @@
 #include "InventoryMenu.h"
 #include <iostream>
 
-InventoryMenu::InventoryMenu(Inventory& inventory, const sf::Vector2f& position, const sf::Vector2f& slotSize,
-    const sf::Vector2f& playerPos, std::vector<DroppedItem>& droppedItems)
-    : mInventory(inventory), mPosition(position), mSlotSize(slotSize), mHoveredSlot(-1), mDraggedSlot(-1),
-    mPlayerPos(playerPos), mDroppedItems(droppedItems) {
+InventoryMenu::InventoryMenu(Inventory& inventory, const sf::Vector2f& position, MainCharacter& character,
+    const sf::Vector2f& slotSize, const sf::Vector2f& playerPos, std::vector<DroppedItem>& droppedItems)
+    : mCharacter(character), mInventory(inventory), mPosition(position), mSlotSize(slotSize),
+    mHoveredSlot(-1), mDraggedSlot(-1), mPlayerPos(playerPos), mDroppedItems(droppedItems) {
     int totalSlots = mInventory.getSlotCount();
     mSlots.resize(totalSlots);
     for (int i = 0; i < totalSlots; ++i) {
@@ -50,6 +50,10 @@ void InventoryMenu::render(sf::RenderWindow& window) {
             window.draw(mTooltipText);
         }
     }
+
+    sf::Sprite characterSprite = mCharacter.getIconSprite();
+    characterSprite.setPosition(sf::Vector2f(mPosition.x - mSlotSize.x * 3.6f, mPosition.y));
+    window.draw(characterSprite);
 }
 
 void InventoryMenu::updateHover(const sf::Vector2f& mousePos) {

--- a/src/Rpg/inventory/InventoryMenu.h
+++ b/src/Rpg/inventory/InventoryMenu.h
@@ -6,9 +6,8 @@
 
 class InventoryMenu {
 public:
-    InventoryMenu(Inventory& inventory, const sf::Vector2f& position, MainCharacter& character,
-                  const sf::Vector2f& slotSize, const sf::Vector2f& playerPos,
-                  std::vector<DroppedItem>& droppedItems);
+    InventoryMenu(Inventory& inventory, const sf::Vector2f& position,
+                  MainCharacter& character, const sf::Vector2f& slotSize);
 
     void render(sf::RenderWindow& window);
     void handleMouseClick(const sf::Vector2f& mousePos);
@@ -22,14 +21,15 @@ public:
 
 private:
     MainCharacter& mCharacter;
+    sf::Sprite mCharacterSprite;
 
     Inventory& mInventory;
     std::vector<sf::RectangleShape> mSlots;
     sf::Vector2f mSlotSize;
     sf::Vector2f mPosition;
-    const sf::Vector2f& mPlayerPos;
     int mHoveredSlot;
     int mDraggedSlot;
+    float mGap;
 
     // Tooltip elements
     sf::RectangleShape mTooltipBackground;
@@ -39,7 +39,5 @@ private:
     void updateSlotColors();
     int getSlotIndexAtPosition(const sf::Vector2f& pos) const;
     void updateTooltip();
-
-    std::vector<DroppedItem>& mDroppedItems;
 };
 

--- a/src/Rpg/inventory/InventoryMenu.h
+++ b/src/Rpg/inventory/InventoryMenu.h
@@ -1,11 +1,12 @@
 #pragma once
 #include <SFML/Graphics.hpp>
+#include "../mainCharacter/MainCharacter.h"
 #include "Inventory.h"
 #include "items/DroppedItem.h"
 
 class InventoryMenu {
 public:
-    InventoryMenu(Inventory& inventory, const sf::Vector2f& position,
+    InventoryMenu(Inventory& inventory, const sf::Vector2f& position, MainCharacter& character,
                   const sf::Vector2f& slotSize, const sf::Vector2f& playerPos,
                   std::vector<DroppedItem>& droppedItems);
 
@@ -20,6 +21,8 @@ public:
     void restart();
 
 private:
+    MainCharacter& mCharacter;
+
     Inventory& mInventory;
     std::vector<sf::RectangleShape> mSlots;
     sf::Vector2f mSlotSize;

--- a/src/Rpg/inventory/InventoryMenu.h
+++ b/src/Rpg/inventory/InventoryMenu.h
@@ -31,6 +31,11 @@ private:
     int mDraggedSlot;
     float mGap;
 
+    sf::Text mLevelText;
+    sf::Text mXpText;
+    sf::RectangleShape mXpBar;
+    sf::RectangleShape mXpBarFill;
+
     // Tooltip elements
     sf::RectangleShape mTooltipBackground;
     sf::Text mTooltipText;

--- a/src/Rpg/mainCharacter/LevelSystem.cpp
+++ b/src/Rpg/mainCharacter/LevelSystem.cpp
@@ -56,5 +56,6 @@ float LevelSystem::getXpPercentage() const {
 
 void LevelSystem::setXp(int xp) {
     mCurrentXp = xp;
+    checkLevelUp();
 }
 

--- a/src/Rpg/mainCharacter/MainCharacter.cpp
+++ b/src/Rpg/mainCharacter/MainCharacter.cpp
@@ -22,6 +22,11 @@ MainCharacter::MainCharacter(const sf::Vector2f& position, Inventory* inventory,
     mAnimations[int(AnimationIndex::WalkingDown)] = Animation(0, 0, 64, 64, "assets/sprites/mainCharacter/walkDown.png", 6, 1.6f);
     mAnimations[int(AnimationIndex::WalkingLeft)] = Animation(0, 0, 64, 64, "assets/sprites/mainCharacter/walkLeft.png", 6, 1.52f);
     mAnimations[int(AnimationIndex::WalkingRight)] = Animation(0, 0, 64, 64, "assets/sprites/mainCharacter/walkRight.png", 6, 1.52f);
+
+    mIconSprite.setTextureRect({ 0, 0, 64, 64 });
+    mIconTexture = Animation(0, 0, 28, 64, "assets/sprites/mainCharacter/idleDown.png", 1, 0.0f);
+    mIconTexture.applyToSprite(mIconSprite);
+    mIconSprite.setScale({ 2.7f, 2.7f });
 }
 
 void MainCharacter::update(float dt, bool inDialogue) {
@@ -189,3 +194,10 @@ void MainCharacter::setXp(int xp) {
     mLevelSystem.setXp(xp);
 }
 
+sf::Sprite& MainCharacter::getSprite() {
+    return mSprite;
+}
+
+sf::Sprite& MainCharacter::getIconSprite() {
+    return mIconSprite;
+}

--- a/src/Rpg/mainCharacter/MainCharacter.cpp
+++ b/src/Rpg/mainCharacter/MainCharacter.cpp
@@ -190,8 +190,16 @@ int MainCharacter::getXpForNextLevel() const {
     return mLevelSystem.getXpForNextLevel();
 }
 
+float MainCharacter::getXpPercentage() const {
+    return mLevelSystem.getXpPercentage();
+}
+
 void MainCharacter::setXp(int xp) {
     mLevelSystem.setXp(xp);
+}
+
+void MainCharacter::addXp(int xp) {
+    mLevelSystem.addXp(xp);
 }
 
 sf::Sprite& MainCharacter::getSprite() {

--- a/src/Rpg/mainCharacter/MainCharacter.h
+++ b/src/Rpg/mainCharacter/MainCharacter.h
@@ -34,6 +34,9 @@ public:
     int getXpForNextLevel() const;
     void setXp(int xp);
 
+    sf::Sprite& getSprite();
+    sf::Sprite& getIconSprite();
+
 private:
     enum class AnimationIndex {
         IdleUp,
@@ -56,6 +59,9 @@ private:
     sf::Sprite mSprite;
     Animation mAnimations[int(AnimationIndex::Count)];
     AnimationIndex mCurrentAnimation = AnimationIndex::IdleDown;
+
+    sf::Sprite mIconSprite;
+    Animation mIconTexture;
 
     sf::RectangleShape mCollisionZone;
     sf::RectangleShape mInteractZone;

--- a/src/Rpg/mainCharacter/MainCharacter.h
+++ b/src/Rpg/mainCharacter/MainCharacter.h
@@ -32,7 +32,9 @@ public:
 
     int getXp() const;
     int getXpForNextLevel() const;
+    float getXpPercentage() const;
     void setXp(int xp);
+    void addXp(int xp);
 
     sf::Sprite& getSprite();
     sf::Sprite& getIconSprite();

--- a/src/Rpg/menues/Menu.cpp
+++ b/src/Rpg/menues/Menu.cpp
@@ -24,6 +24,7 @@ Menu::Menu(sf::RenderWindow& window, SkillTree& skillTree, Inventory& inventory,
     mInventoryMenu = std::make_unique<InventoryMenu>(inventory,
                                                      sf::Vector2f(mMenuShape.getPosition().x + mMenuShape.getSize().x / 2,
                                                                   mMenuShape.getPosition().y + mMenuShape.getSize().y / 3),
+                                                     rpgEngine.getPlayer(),
                                                      sf::Vector2f(70.0f, 70.0f), playerPos, droppedItems);
 
     mHoveredZoneShape.setSize(sf::Vector2f(window.getSize().x / 2.0f, 58));

--- a/src/Rpg/menues/Menu.cpp
+++ b/src/Rpg/menues/Menu.cpp
@@ -4,33 +4,36 @@
 #include "../../GameManager.h"
 
 Menu::Menu(sf::RenderWindow& window, SkillTree& skillTree, Inventory& inventory,
-          const sf::Vector2f& playerPos, std::vector<DroppedItem>& droppedItems,
-          RPGEngine& rpgEngine, GameManager* gameManager)
-    : mCurrentMenu("Inventory"), mGameManager(gameManager),
-    inventoryButton(sf::Vector2f(0, 0), sf::Vector2f(80.0f, 35.0f), "Inventory"),
-    skillTreeButton(sf::Vector2f(0, 0), sf::Vector2f(80.0f, 35.0f), "SkillTree"),
-    exitButton(sf::Vector2f(0, 0), sf::Vector2f(80.0f, 35.0f), "Exit"), mShowText(false) {
+           RPGEngine& rpgEngine, GameManager* gameManager)
+    : mCurrentMenu("Inventory"), mGameManager(gameManager), mGap(0),
+    mInventoryButton(sf::Vector2f(0, 0), sf::Vector2f(80.0f, 35.0f), "Inventory"),
+    mSkillTreeButton(sf::Vector2f(0, 0), sf::Vector2f(80.0f, 35.0f), "SkillTree"),
+    mExitButton(sf::Vector2f(0, 0), sf::Vector2f(80.0f, 35.0f), "Exit"), mShowText(false) {
 
     if (!mFont.loadFromFile("assets/fonts/gameFont.ttf"))
         std::cout << "Couldn't load font" << std::endl;
+
+    mBackground.setSize(sf::Vector2f(window.getSize().x, window.getSize().y));
+    mBackground.setFillColor(sf::Color(50, 50, 50, 185));
+    mBackground.setPosition(sf::Vector2f(0, 0));
 
     mMenuShape.setSize(sf::Vector2f(window.getSize().x / 2.0f, window.getSize().y / 2.0f));
     mMenuShape.setFillColor(sf::Color(50, 50, 50, 255));
     mMenuShape.setPosition((window.getSize().x - mMenuShape.getSize().x) / 2.0f,
                            (window.getSize().y - mMenuShape.getSize().y) / 2.0f);
 
-    mSkillTreeMenu = std::make_unique<SkillTreeMenu>(sf::Vector2f(mMenuShape.getPosition().x + 10.0f, mMenuShape.getPosition().y + 100.0f),
-                                                     sf::Vector2f(mMenuShape.getSize().x - 20.0f, mMenuShape.getSize().y - 110.0f), skillTree);
-    mInventoryMenu = std::make_unique<InventoryMenu>(inventory,
-                                                     sf::Vector2f(mMenuShape.getPosition().x + mMenuShape.getSize().x / 2,
-                                                                  mMenuShape.getPosition().y + mMenuShape.getSize().y / 3),
-                                                     rpgEngine.getPlayer(),
-                                                     sf::Vector2f(70.0f, 70.0f), playerPos, droppedItems);
-
-    mHoveredZoneShape.setSize(sf::Vector2f(window.getSize().x / 2.0f, 58));
+    mHoveredZoneShape.setSize(sf::Vector2f(mMenuShape.getSize().x, mMenuShape.getSize().y * 0.155f));
     mHoveredZoneShape.setFillColor(sf::Color(10, 10, 10, 100));
-    mHoveredZoneShape.setPosition(sf::Vector2f((window.getSize().x - mMenuShape.getSize().x) / 2.0f,
-                                               (window.getSize().y - mMenuShape.getSize().y) / 2.0f));
+    mHoveredZoneShape.setPosition(mMenuShape.getPosition());
+
+    mSkillTreeMenu = std::make_unique<SkillTreeMenu>(sf::Vector2f(mMenuShape.getPosition().x + mMenuShape.getSize().x * 0.156f, mMenuShape.getPosition().y + mMenuShape.getSize().y * 0.277f),
+                                                     sf::Vector2f(mMenuShape.getSize().x * 0.968f, mMenuShape.getSize().y * 0.694f), skillTree);
+    float slotSize = mMenuShape.getSize().y * 0.195f;
+    mInventoryMenu = std::make_unique<InventoryMenu>(inventory,
+                                                     sf::Vector2f(mMenuShape.getPosition().x + mMenuShape.getSize().x / 2.f,
+                                                                  mMenuShape.getPosition().y + mHoveredZoneShape.getSize().y +
+                                                                  (mMenuShape.getSize().y - mHoveredZoneShape.getSize().y) / 4.f),
+                                                     rpgEngine.getPlayer(), sf::Vector2f(slotSize, slotSize));
 
     mErrorText.setFillColor(sf::Color::White);
     mErrorText.setFont(mFont);
@@ -39,20 +42,24 @@ Menu::Menu(sf::RenderWindow& window, SkillTree& skillTree, Inventory& inventory,
     mErrorText.setPosition(sf::Vector2f(mMenuShape.getPosition().x + mMenuShape.getSize().x * 0.05f,
                                         mMenuShape.getPosition().y + mMenuShape.getSize().y * 0.2f));
 
-    sf::Vector2f buttonSize(80.0f, 35.0f);
-    float startX = mMenuShape.getPosition().x + 20.0f;
-    float startY = mMenuShape.getPosition().y + 10.0f;
-    float gap = 20.0f;
+    sf::Vector2f buttonSize(mHoveredZoneShape.getSize().x * 0.12f, mHoveredZoneShape.getSize().y * 0.6f);
+    mInventoryButton.setSize(buttonSize);
+    mSkillTreeButton.setSize(buttonSize);
+    mExitButton.setSize(buttonSize);
 
-    inventoryButton.setPosition(sf::Vector2f(startX, startY));
-    skillTreeButton.setPosition(sf::Vector2f(startX + buttonSize.x + gap, startY));
-    exitButton.setPosition(sf::Vector2f(mMenuShape.getPosition().x + mMenuShape.getSize().x - buttonSize.x - gap, startY));
+    mGap = mHoveredZoneShape.getSize().x * 0.04f;;
+    float startX = mHoveredZoneShape.getPosition().x + mGap;
+    float startY = mHoveredZoneShape.getPosition().y + (mHoveredZoneShape.getSize().y - buttonSize.y) / 2.f;
 
-    inventoryButton.setCallback([&]() {
+    mInventoryButton.setPosition(sf::Vector2f(startX, startY));
+    mSkillTreeButton.setPosition(sf::Vector2f(startX + buttonSize.x + mGap, startY));
+    mExitButton.setPosition(sf::Vector2f(mMenuShape.getPosition().x + mMenuShape.getSize().x - buttonSize.x - mGap, startY));
+
+    mInventoryButton.setCallback([&]() {
         switchToMenu("Inventory");
     });
 
-    skillTreeButton.setCallback([&]() {
+    mSkillTreeButton.setCallback([&]() {
         // TODO : Implement prototype of skill tree menu
         // For now only an error message is displayed
         //switchToMenu("SkillTree");
@@ -61,7 +68,7 @@ Menu::Menu(sf::RenderWindow& window, SkillTree& skillTree, Inventory& inventory,
         mShowText = true;
     });
 
-    exitButton.setCallback([&]() {
+    mExitButton.setCallback([&]() {
         rpgEngine.saveGame();
         if (mGameManager)
             mGameManager->switchToMainMenu();
@@ -69,15 +76,15 @@ Menu::Menu(sf::RenderWindow& window, SkillTree& skillTree, Inventory& inventory,
             std::cerr << "Error: GameManager is nullptr in exitButton callback." << std::endl;
     });
 
-    mButtons.push_back(inventoryButton);
-    mButtons.push_back(skillTreeButton);
-    mButtons.push_back(exitButton);
+    mButtons.push_back(mInventoryButton);
+    mButtons.push_back(mSkillTreeButton);
+    mButtons.push_back(mExitButton);
 
     mCrystalText.setFont(mFont);
-    mCrystalText.setCharacterSize(14);
+    mCrystalText.setCharacterSize(13);
     mCrystalText.setFillColor(sf::Color::White);
-    mCrystalText.setPosition(mMenuShape.getPosition().x + mMenuShape.getSize().x - mCrystalText.getGlobalBounds().width - 230.0f,
-                             mMenuShape.getPosition().y + 15.0f);
+    mCrystalText.setPosition(mMenuShape.getPosition().x + mMenuShape.getSize().x - mCrystalText.getGlobalBounds().width - mExitButton.getSize().x - mGap * 1.6f,
+                             mMenuShape.getPosition().y + (mHoveredZoneShape.getSize().y - mCrystalText.getGlobalBounds().height) / 2.f);
 }
 
 void Menu::handleMouseClick(const sf::Vector2f& mousePos)
@@ -116,8 +123,10 @@ void Menu::restart() {
 
 void Menu::update(int crystals, const Inventory& inventory, const SkillTree& skillTree) {
     mCrystalText.setString("Crystals " + std::to_string(crystals));
+    mCrystalText.setPosition(mMenuShape.getPosition().x + mMenuShape.getSize().x - mCrystalText.getGlobalBounds().width - mExitButton.getSize().x - mGap * 1.6f,
+                             mMenuShape.getPosition().y + (mHoveredZoneShape.getSize().y - mCrystalText.getGlobalBounds().height) / 2.f);
 
-    skillTreeButton.setCallback([&]() {
+    mSkillTreeButton.setCallback([&]() {
         // TODO : Implement prototype of skill tree menu
         // For now only an error message is displayed
         //switchToMenu("SkillTree");
@@ -142,6 +151,7 @@ InventoryMenu& Menu::getInventoryMenu() {
 }
 
 void Menu::render(sf::RenderWindow& window) {
+    window.draw(mBackground);
     window.draw(mMenuShape);
     window.draw(mHoveredZoneShape);
     window.draw(mCrystalText);

--- a/src/Rpg/menues/Menu.h
+++ b/src/Rpg/menues/Menu.h
@@ -14,7 +14,7 @@ class GameManager;
 class Menu {
 public:
     Menu(sf::RenderWindow& window, SkillTree& skillTree, Inventory& inventory,
-         const sf::Vector2f& playerPos, std::vector<DroppedItem>& droppedItems, RPGEngine& rpgEngine, GameManager* gameManager);
+         RPGEngine& rpgEngine, GameManager* gameManager);
 
     void render(sf::RenderWindow& window);
     void handleMouseClick(const sf::Vector2f& mousePos);
@@ -27,14 +27,16 @@ public:
     InventoryMenu& getInventoryMenu();
 
 private:
+    sf::RectangleShape mBackground;
     sf::RectangleShape mMenuShape;
     sf::RectangleShape mHoveredZoneShape;
     GameManager* mGameManager;
 
     std::vector<Button> mButtons;
-    Button skillTreeButton;
-    Button inventoryButton;
-    Button exitButton;
+    Button mSkillTreeButton;
+    Button mInventoryButton;
+    Button mExitButton;
+    float mGap;
 
     std::string mCurrentMenu;
     std::unique_ptr<SkillTreeMenu> mSkillTreeMenu;

--- a/src/Rpg/npcs/NPC.cpp
+++ b/src/Rpg/npcs/NPC.cpp
@@ -229,10 +229,6 @@ void NPC::setInteract(bool showInteract) {
     mShowInteract = showInteract;
 }
 
-sf::Sprite& NPC::getSprite() {
-    return mIconSprite;
-}
-
 void NPC::startPause(float duration) {
     mIsPaused = true;
     mPauseDuration = duration;
@@ -272,3 +268,10 @@ std::vector<DialogueAction> NPC::getCurrentDialogueActions() const {
     return mDialogueManager.getCurrentActions();
 }
 
+sf::Sprite& NPC::getSprite() {
+    return mSprite;
+}
+
+sf::Sprite& NPC::getIconSprite() {
+    return mIconSprite;
+}

--- a/src/Rpg/npcs/NPC.h
+++ b/src/Rpg/npcs/NPC.h
@@ -54,6 +54,7 @@ public:
 
     std::string getID() const { return mId; }
     sf::Sprite& getSprite();
+    sf::Sprite& getIconSprite();
 
 protected:
     std::string mId;

--- a/src/TowerDefense/menues/Button.cpp
+++ b/src/TowerDefense/menues/Button.cpp
@@ -53,8 +53,22 @@ void Button::onClick() {
 }
 
 void Button::setPosition(const sf::Vector2f& position) {
-    mButtonShape.setPosition(position);
-    mButtonText.setPosition(position.x + mSize.x / 2.0f, position.y + mSize.y / 2.0f);
+    mPosition = position;
+    mButtonShape.setPosition(mPosition);
+
+    sf::FloatRect rect = mButtonText.getLocalBounds();
+    mButtonText.setOrigin(rect.left + rect.width / 2.f, rect.top + rect.height / 2.f);
+    mButtonText.setPosition(mPosition.x + mSize.x / 2.0f, mPosition.y + mSize.y / 2.0f);
+}
+
+void Button::setSize(const sf::Vector2f& size) {
+    mSize = size;
+    mButtonShape.setSize(mSize);
+    mButtonText.setCharacterSize(static_cast<int>(mSize.y * 0.42f));
+
+    sf::FloatRect rect = mButtonText.getLocalBounds();
+    mButtonText.setOrigin(rect.left + rect.width / 2.f, rect.top + rect.height / 2.f);
+    mButtonText.setPosition(mPosition.x + mSize.x / 2.0f, mPosition.y + mSize.y / 2.0f);
 }
 
 void Button::setText(const std::string& text) {

--- a/src/TowerDefense/menues/Button.h
+++ b/src/TowerDefense/menues/Button.h
@@ -14,6 +14,7 @@ public:
     void onClick();
 
     void setPosition(const sf::Vector2f& position);
+    void setSize(const sf::Vector2f& size);
     void setText(const std::string& text);
 
     void setBackgroundColor(sf::Color color);


### PR DESCRIPTION
## **Title** 
[#79] Add player profile in `InventoryMenu`

## **Description**  
**What changes did you make?**  
Added a player profile which displays the player icon, level and an XP bar.

**Why are these changes needed?**   
User needed a way to know the player level and XP progression.

**Related Issue:**  
Fixes #79 

## **Type of Change**  
- [ ] Bug fix 
- [x] New feature
- [x] Code Refactor
- [ ]  Documentation update 

## **Checklist**  
- [x] **Self-Review**: I checked my own changes for mistakes.    
- [ ] **Docs**: Updated documentation if required.  
- [x] **Zero Warnings**: Changes don’t introduce new compiler/linter warnings.

