### PR TITLE
Add delete action for occupied save slots

### DIFF
--- a/src/MainMenu/MainMenu.cpp
+++ b/src/MainMenu/MainMenu.cpp
@@ -14,7 +14,10 @@ MainMenu::MainMenu(sf::RenderWindow& window, GameManager* gameManager)
       mGame1Button(sf::Vector2f(0.0f, 0.0f), sf::Vector2f(140.f, 50.f), "New Game"),
       mGame2Button(sf::Vector2f(0.0f, 0.0f), sf::Vector2f(140.f, 50.f), "New Game"),
       mGame3Button(sf::Vector2f(0.0f, 0.0f), sf::Vector2f(140.f, 50.f), "New Game"),
-      mBackPlayButton(sf::Vector2f(0.0f, 0.0f), sf::Vector2f(140.f, 50.f), "Back") {
+      mBackPlayButton(sf::Vector2f(0.0f, 0.0f), sf::Vector2f(140.f, 50.f), "Back"),
+      mDelete1Button(sf::Vector2f(0.0f, 0.0f), sf::Vector2f(70.f, 28.f), "Delete"),
+      mDelete2Button(sf::Vector2f(0.0f, 0.0f), sf::Vector2f(70.f, 28.f), "Delete"),
+      mDelete3Button(sf::Vector2f(0.0f, 0.0f), sf::Vector2f(70.f, 28.f), "Delete") {
 
     if (!mFont.loadFromFile("assets/fonts/gameFont.ttf"))
         std::cout << "Couldn't load font from file" << std::endl;
@@ -127,6 +130,12 @@ MainMenu::MainMenu(sf::RenderWindow& window, GameManager* gameManager)
                                          mWindow.getSize().y * 2 / 3.6f));
     mBackPlayButton.setPosition(sf::Vector2f((mWindow.getSize().x - mPlayButton.getSize().x) / 2.f,
                                               mWindow.getSize().y * 2 / 2.3f));
+    mDelete1Button.setPosition(sf::Vector2f(mSave1Rectangle.getPosition().x + (mSave1Rectangle.getSize().x - mDelete1Button.getSize().x) / 2.f,
+                                             mSave1Rectangle.getPosition().y + mSave1Rectangle.getSize().y + 10.f));
+    mDelete2Button.setPosition(sf::Vector2f(mSave2Rectangle.getPosition().x + (mSave2Rectangle.getSize().x - mDelete2Button.getSize().x) / 2.f,
+                                             mSave2Rectangle.getPosition().y + mSave2Rectangle.getSize().y + 10.f));
+    mDelete3Button.setPosition(sf::Vector2f(mSave3Rectangle.getPosition().x + (mSave3Rectangle.getSize().x - mDelete3Button.getSize().x) / 2.f,
+                                             mSave3Rectangle.getPosition().y + mSave3Rectangle.getSize().y + 10.f));
 
     mPlayButton.setCallback([&]() {
         mShowGameButtons = true;
@@ -154,6 +163,19 @@ MainMenu::MainMenu(sf::RenderWindow& window, GameManager* gameManager)
 
     mBackPlayButton.setCallback([&]() {
         mShowGameButtons = false;
+    });
+
+    mDelete1Button.setCallback([&]() {
+        mGameManager->getGameEngine().deleteSave(1);
+        updateSaves();
+    });
+    mDelete2Button.setCallback([&]() {
+        mGameManager->getGameEngine().deleteSave(2);
+        updateSaves();
+    });
+    mDelete3Button.setCallback([&]() {
+        mGameManager->getGameEngine().deleteSave(3);
+        updateSaves();
     });
     
     updateSaves();
@@ -191,6 +213,13 @@ void MainMenu::processEvents() {
                         if (button.isMouseOver(mousePos))
                             button.onClick();
                     }
+
+                    if (mGameManager->getGameEngine().saveExists(1) && mDelete1Button.isMouseOver(mousePos))
+                        mDelete1Button.onClick();
+                    if (mGameManager->getGameEngine().saveExists(2) && mDelete2Button.isMouseOver(mousePos))
+                        mDelete2Button.onClick();
+                    if (mGameManager->getGameEngine().saveExists(3) && mDelete3Button.isMouseOver(mousePos))
+                        mDelete3Button.onClick();
                 }
             }
         }
@@ -207,6 +236,12 @@ void MainMenu::update() {
         for (auto& button: mPlayButtons) {
             button.updateHover(mousePos);
         }
+        if (mGameManager->getGameEngine().saveExists(1))
+            mDelete1Button.updateHover(mousePos);
+        if (mGameManager->getGameEngine().saveExists(2))
+            mDelete2Button.updateHover(mousePos);
+        if (mGameManager->getGameEngine().saveExists(3))
+            mDelete3Button.updateHover(mousePos);
     }
 }
 
@@ -242,6 +277,12 @@ void MainMenu::render() {
         for (auto& button: mPlayButtons) {
             button.render(mWindow);
         }
+        if (mGameManager->getGameEngine().saveExists(1))
+            mDelete1Button.render(mWindow);
+        if (mGameManager->getGameEngine().saveExists(2))
+            mDelete2Button.render(mWindow);
+        if (mGameManager->getGameEngine().saveExists(3))
+            mDelete3Button.render(mWindow);
     }
 
     mWindow.display();

--- a/src/MainMenu/MainMenu.h
+++ b/src/MainMenu/MainMenu.h
@@ -31,6 +31,9 @@ private:
     Button mGame2Button;
     Button mGame3Button;
     Button mBackPlayButton;
+    Button mDelete1Button;
+    Button mDelete2Button;
+    Button mDelete3Button;
     std::vector<Button> mPlayButtons;
 
     sf::RectangleShape mSave1Rectangle;

--- a/src/Rpg/gamengine/RPGEngine.cpp
+++ b/src/Rpg/gamengine/RPGEngine.cpp
@@ -1065,6 +1065,26 @@ bool RPGEngine::saveExists(int saveNumber) const {
     return false;
 }
 
+bool RPGEngine::deleteSave(int saveNumber) {
+    std::string filename;
+    if (saveNumber == 1)
+        filename = "save1.txt";
+    else if (saveNumber == 2)
+        filename = "save2.txt";
+    else if (saveNumber == 3)
+        filename = "save3.txt";
+    else
+        return false;
+
+    std::error_code error;
+    const bool removed = std::filesystem::remove(filename, error);
+    if (!removed && error) {
+        std::cerr << "Failed to delete save file: " << filename << std::endl;
+        return false;
+    }
+
+    return true;
+}
 
 void RPGEngine::newGame() {
     std::string filename;

--- a/src/Rpg/gamengine/RPGEngine.h
+++ b/src/Rpg/gamengine/RPGEngine.h
@@ -57,6 +57,7 @@ public:
     void resetSaveGame();
     void resetToDefault();
     bool saveExists(int saveNumber) const;
+    bool deleteSave(int saveNumber);
     void newGame();
     void setSaveNumber(int saveNumber);
     void setFlag(std::string name, bool value);


### PR DESCRIPTION
## **Title** 
[#103] Add delete action for occupied save slots

## **Description**  
**What changes did you make?**  
*Added a Delete button under each save slot container
Made the button visible only for occupied save slots
Implemented save-file deletion logic and refreshed the menu state after removal

**Why are these changes needed?**   
This makes the save system more user-friendly and avoids the need for players to manually manage save files outside the game.

**Related Issue:**  
Fixes #(103) 

## **Type of Change**  
New feature


## **Checklist**  
- **Self-Review**: I checked my own changes for mistakes.    